### PR TITLE
Improve chat not found message

### DIFF
--- a/main.py
+++ b/main.py
@@ -282,7 +282,9 @@ async def process_add_chats(message: types.Message, state: FSMContext):
                 ent = await client.get_entity(part)
                 new_ids.append(ent.id)
             except:
-                await message.reply("⚠️ Чат не найден. Повторите ввод:")
+                await message.reply(
+                    "⚠️ Чат не найден. Проверьте, что он есть в вашем аккаунте или ссылка корректна, затем повторите ввод:"
+                )
                 return
     usr = user_data[str(message.from_user.id)]
     usr.setdefault('chats', [])


### PR DESCRIPTION
## Summary
- clarify instructions when chat is not found during chat addition

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68509d3801f0832d8287707549e17f99