### PR TITLE
Fix menu command not resetting state

### DIFF
--- a/main.py
+++ b/main.py
@@ -426,7 +426,8 @@ async def cmd_start(message: types.Message, state: FSMContext):
 
 
 @dp.message_handler(commands=['menu'], state="*")
-async def cmd_menu(message: types.Message):
+async def cmd_menu(message: types.Message, state: FSMContext):
+    await state.finish()
     await message.answer(t('menu_main'), reply_markup=main_menu_keyboard())
 
 


### PR DESCRIPTION
## Summary
- reset FSM state in /menu handler to restore main menu buttons

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_688ea2a8b3e4832daf895d4536720adf