### PR TITLE
Fix duplicate parser insertion when adding second parser

### DIFF
--- a/main.py
+++ b/main.py
@@ -1038,7 +1038,9 @@ async def cmd_add_parser(message: types.Message, state: FSMContext):
     }
     parsers.append(parser)
     info = user_clients.setdefault(user_id, info or {})
-    info.setdefault('parsers', []).append(parser)
+    # Avoid duplicating the parser in runtime storage; ensure both
+    # user_clients and persistent user_data reference the same list.
+    info['parsers'] = parsers
     save_user_data(user_data)
     await message.answer(
         parser_info_text(user_id, parser, created=True),


### PR DESCRIPTION
## Summary
- avoid adding the same parser twice to runtime list

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_688ea2caa7e4832da5acdaa7da38bf86